### PR TITLE
Updated root element name in FIRESTONE_bios.xml

### DIFF
--- a/FIRESTONE_bios.xml
+++ b/FIRESTONE_bios.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 
-<bios>
-</bios>
+<firmware-overrides>
+</firmware-overrides>


### PR DESCRIPTION
Note: FIRESTONE_bios.xml accidentally directly merged into firestone-xml package, and with wrong root element tag; this fixes the tag. 
