### PR TITLE
Remove EEPROM_VPD_FRU_INFO from firestone xml

### DIFF
--- a/firestone.xml
+++ b/firestone.xml
@@ -5563,20 +5563,6 @@
 		</default>
 	</attribute>
 	<attribute>
-		<id>EEPROM_VPD_FRU_INFO</id>
-		<default>
-				<field><id>i2cMasterPath</id><value>physical:sys-0/node-0/proc-0</value></field>
-				<field><id>port</id><value>0</value></field>
-				<field><id>devAddr</id><value>0xA0</value></field>
-				<field><id>engine</id><value>0</value></field>
-				<field><id>byteAddrOffset</id><value>0x02</value></field>
-				<field><id>maxMemorySizeKB</id><value>0x40</value></field>
-				<field><id>writePageSize</id><value>0x80</value></field>
-				<field><id>writeCycleTime</id><value>0x05</value></field>
-				<field><id>fruId</id><value>0++</value></field>
-		</default>
-	</attribute>
-	<attribute>
 		<id>EEPROM_VPD_PRIMARY_INFO</id>
 		<default>
 				<field><id>i2cMasterPath</id><value>physical:sys-0/node-0/proc-0</value></field>


### PR DESCRIPTION
Needed for firestone makefiles to work.
