### PR TITLE
Moved load line attribute instances to proc target

### DIFF
--- a/FIRESTONE_hb.mrw.xml
+++ b/FIRESTONE_hb.mrw.xml
@@ -368,30 +368,6 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
-		<id>PROC_R_DISTLOSS_VCS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_R_DISTLOSS_VDD</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_R_LOADLINE_VCS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_R_LOADLINE_VDD</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_VRM_VOFFSET_VCS</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>PROC_VRM_VOFFSET_VDD</id>
-		<default></default>
-	</attribute>
-	<attribute>
 		<id>PROC_X_BUS_WIDTH</id>
 		<default>2</default>
 	</attribute>
@@ -832,6 +808,30 @@
 	<attribute>
 		<id>VPD_REC_NUM</id>
 		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_DISTLOSS_VCS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_DISTLOSS_VDD</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_LOADLINE_VCS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_LOADLINE_VDD</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_VRM_VOFFSET_VCS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_VRM_VOFFSET_VDD</id>
+		<default></default>
 	</attribute>
 </targetInstance>
 <targetInstance>
@@ -4316,6 +4316,30 @@
 	<attribute>
 		<id>VPD_REC_NUM</id>
 		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_DISTLOSS_VCS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_DISTLOSS_VDD</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_LOADLINE_VCS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_R_LOADLINE_VDD</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_VRM_VOFFSET_VCS</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>PROC_VRM_VOFFSET_VDD</id>
+		<default></default>
 	</attribute>
 </targetInstance>
 <targetInstance>


### PR DESCRIPTION
Requires Hostboot commit that moves loadline attributes to proc target
