### PR TITLE
Enable PSI BARs to get interrupts from second proc

### DIFF
--- a/firestone.xml
+++ b/firestone.xml
@@ -5785,7 +5785,7 @@
 	</attribute>
 	<attribute>
 		<id>PSI_BRIDGE_BASE_ADDR</id>
-		<default>0,0x0000000000000000</default>
+		<default>1,0x0003FFFE80000000,0x2000000,0x400000,0x0</default>
 	</attribute>
 	<attribute>
 		<id>RNG_BASE_ADDR</id>


### PR DESCRIPTION
Modified calculation for PSI BAR to get a non-zero value.  This
is needed to get attention interrupts from the second processor.
