### PR TITLE
FRU list appears to have extraneous data in output

### DIFF
--- a/firestone.rpt
+++ b/firestone.rpt
@@ -1,178 +1,178 @@
-                    Sensor Name |   FRU Name | Ent ID | Type |   ID | Inst |  FRU | Target
- ------------------------------ | ---------- | ------ | ---- | ---- | ---- | ---- | ----------
-              SYS0_System_Event |       SYS0 |  0x01  | 0x12 | 0x52 |    0 |    0 | /sys-0
-               SYS0_Host_Status |       SYS0 |  0x23  | 0x22 | 0x04 |    0 |    0 | /sys-0
-    SYS0_Firmware_Boot_Progress |       SYS0 |  0x22  | 0x0F | 0x05 |    0 |    0 | /sys-0
-         SYS0_PCIE_Link_Present |       SYS0 |  0x23  | 0xC4 | 0x5B |    0 |    0 | /sys-0
-                   SYS0_OS_Boot |       SYS0 |  0x23  | 0x1F | 0x5A |    0 |    0 | /sys-0
-                 SYS0_Power_Cap |       SYS0 |  0x17  | 0xC2 | 0x58 |    0 |    0 | /sys-0
-                SYS0_Boot_count |       SYS0 |  0x22  | 0xC3 | 0x50 |    0 |    0 | /sys-0
-        SYS0_Power_Limit_Active |       SYS0 |  0x15  | 0xC6 | 0x53 |    0 |    0 | /sys-0
-        SYS0_PS_Derating_Factor |       SYS0 |  0x15  | 0xC8 |  Err |    0 |    0 | /sys-0
-                      SYS0_Freq |       SYS0 |  0x08  | 0xC1 | 0x4F |    0 |    0 | /sys-0
-             Memory_Proc0_Power |            |  0xD7  | 0xC2 | 0xA1 |    0 |    0 | /sys-0
-             Memory_Proc1_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-             Memory_Proc2_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-             Memory_Proc3_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                    Proc0_Power |            |  0xD7  | 0xC2 | 0xA2 |    1 |    0 | /sys-0
-                    Proc1_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                    Proc2_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                    Proc3_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-               PCIE_Proc0_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-               PCIE_Proc1_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-               PCIE_Proc2_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-               PCIE_Proc3_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                     IO_A_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                     IO_B_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                     IO_C_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                    Fan_Power_A |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                    Fan_Power_B |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                Storage_Power_A |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                Storage_Power_B |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-             Total_System_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-             Memory_Cache_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-           Memory_Proc0_0_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-           Memory_Proc0_1_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-           Memory_Proc0_2_Power |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                       12VSense |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                    GroundSense |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-                       GPUSense |            |  0xD7  | 0xC2 |  N/A |    0 |    0 | /sys-0
-        NODE0_Motherboard_Fault |      NODE0 |  0x07  | 0xC7 | 0x51 |    0 |    0 | /sys-0/node-0
-                NODE0_Ref_Clock |      NODE0 |  0xD4  | 0xC7 | 0x54 |    0 |    0 | /sys-0/node-0
-                NODE0_PCI_Clock |      NODE0 |  0xD5  | 0xC7 | 0x55 |    0 |    0 | /sys-0/node-0
-                NODE0_TOD_Clock |      NODE0 |  0xD6  | 0xC7 | 0x56 |    0 |    0 | /sys-0/node-0
-               NODE0_APSS_Fault |      NODE0 |  0xD7  | 0xC7 |  Err |    0 |    0 | /sys-0/node-0
-                     DIMM0_Temp |      DIMM0 |  0x20  | 0x01 | 0x69 |    0 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-0/dimm-0
-                     DIMM0_Func |      DIMM0 |  0x20  | 0x0C | 0x1E |    0 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-0/dimm-0
-                     DIMM1_Temp |      DIMM1 |  0x20  | 0x01 | 0x6A |    1 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-1/dimm-0
-                     DIMM1_Func |      DIMM1 |  0x20  | 0x0C | 0x1F |    1 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-1/dimm-0
-                     DIMM2_Temp |      DIMM2 |  0x20  | 0x01 | 0x6B |    2 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-2/dimm-0
-                     DIMM2_Func |      DIMM2 |  0x20  | 0x0C | 0x20 |    2 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-2/dimm-0
-                     DIMM3_Temp |      DIMM3 |  0x20  | 0x01 | 0x6C |    3 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-3/dimm-0
-                     DIMM3_Func |      DIMM3 |  0x20  | 0x0C | 0x21 |    3 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-3/dimm-0
-                   MEMBUF0_Temp |    MEMBUF0 |  0xD1  | 0x01 | 0x65 |    0 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/membuf-0
-                   MEMBUF0_Func |    MEMBUF0 |  0xD1  | 0x0C | 0x4C |    0 |    0 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/membuf-0
-                     DIMM4_Temp |      DIMM4 |  0x20  | 0x01 | 0x6D |    4 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-0/dimm-0
-                     DIMM4_Func |      DIMM4 |  0x20  | 0x0C | 0x22 |    4 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-0/dimm-0
-                     DIMM5_Temp |      DIMM5 |  0x20  | 0x01 | 0x6E |    5 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-1/dimm-0
-                     DIMM5_Func |      DIMM5 |  0x20  | 0x0C | 0x23 |    5 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-1/dimm-0
-                     DIMM6_Temp |      DIMM6 |  0x20  | 0x01 | 0x6F |    6 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-2/dimm-0
-                     DIMM6_Func |      DIMM6 |  0x20  | 0x0C | 0x24 |    6 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-2/dimm-0
-                     DIMM7_Temp |      DIMM7 |  0x20  | 0x01 | 0x70 |    7 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-3/dimm-0
-                     DIMM7_Func |      DIMM7 |  0x20  | 0x0C | 0x25 |    7 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-3/dimm-0
-                   MEMBUF1_Temp |    MEMBUF1 |  0xD1  | 0x01 | 0x66 |    1 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/membuf-0
-                   MEMBUF1_Func |    MEMBUF1 |  0xD1  | 0x0C |  Err |    1 |    0 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/membuf-0
-                     DIMM8_Temp |      DIMM8 |  0x20  | 0x01 | 0x71 |    8 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-0/dimm-0
-                     DIMM8_Func |      DIMM8 |  0x20  | 0x0C | 0x26 |    8 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-0/dimm-0
-                     DIMM9_Temp |      DIMM9 |  0x20  | 0x01 | 0x72 |    9 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-1/dimm-0
-                     DIMM9_Func |      DIMM9 |  0x20  | 0x0C | 0x27 |    9 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-1/dimm-0
-                    DIMM10_Temp |     DIMM10 |  0x20  | 0x01 | 0x73 |   10 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-2/dimm-0
-                    DIMM10_Func |     DIMM10 |  0x20  | 0x0C | 0x28 |   10 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-2/dimm-0
-                    DIMM11_Temp |     DIMM11 |  0x20  | 0x01 | 0x74 |   11 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-3/dimm-0
-                    DIMM11_Func |     DIMM11 |  0x20  | 0x0C | 0x29 |   11 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-3/dimm-0
-                   MEMBUF2_Temp |    MEMBUF2 |  0xD1  | 0x01 | 0x67 |    2 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/membuf-0
-                   MEMBUF2_Func |    MEMBUF2 |  0xD1  | 0x0C |  Err |    2 |    0 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/membuf-0
-                    DIMM12_Temp |     DIMM12 |  0x20  | 0x01 | 0x75 |   12 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-0/dimm-0
-                    DIMM12_Func |     DIMM12 |  0x20  | 0x0C | 0x2A |   12 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-0/dimm-0
-                    DIMM13_Temp |     DIMM13 |  0x20  | 0x01 | 0x76 |   13 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-1/dimm-0
-                    DIMM13_Func |     DIMM13 |  0x20  | 0x0C | 0x2B |   13 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-1/dimm-0
-                    DIMM14_Temp |     DIMM14 |  0x20  | 0x01 | 0x77 |   14 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-2/dimm-0
-                    DIMM14_Func |     DIMM14 |  0x20  | 0x0C | 0x2C |   14 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-2/dimm-0
-                    DIMM15_Temp |     DIMM15 |  0x20  | 0x01 | 0x78 |   15 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-3/dimm-0
-                    DIMM15_Func |     DIMM15 |  0x20  | 0x0C | 0x2D |   15 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-3/dimm-0
-                   MEMBUF3_Temp |    MEMBUF3 |  0xD1  | 0x01 | 0x68 |    3 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/membuf-0
-                   MEMBUF3_Func |    MEMBUF3 |  0xD1  | 0x0C |  Err |    3 |    0 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/membuf-0
-                    DIMM16_Temp |     DIMM16 |  0x20  | 0x01 | 0x79 |   16 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-0/dimm-0
-                    DIMM16_Func |     DIMM16 |  0x20  | 0x0C | 0x2E |   16 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-0/dimm-0
-                    DIMM17_Temp |     DIMM17 |  0x20  | 0x01 | 0x7A |   17 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-1/dimm-0
-                    DIMM17_Func |     DIMM17 |  0x20  | 0x0C | 0x2F |   17 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-1/dimm-0
-                    DIMM18_Temp |     DIMM18 |  0x20  | 0x01 | 0x7B |   18 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-2/dimm-0
-                    DIMM18_Func |     DIMM18 |  0x20  | 0x0C | 0x30 |   18 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-2/dimm-0
-                    DIMM19_Temp |     DIMM19 |  0x20  | 0x01 | 0x7C |   19 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-3/dimm-0
-                    DIMM19_Func |     DIMM19 |  0x20  | 0x0C | 0x31 |   19 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-3/dimm-0
-                   MEMBUF4_Temp |    MEMBUF4 |  0xD1  | 0x01 |  Err |    4 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/membuf-0
-                   MEMBUF4_Func |    MEMBUF4 |  0xD1  | 0x0C |  Err |    4 |    0 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/membuf-0
-                    DIMM20_Temp |     DIMM20 |  0x20  | 0x01 | 0x7D |   20 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-0/dimm-0
-                    DIMM20_Func |     DIMM20 |  0x20  | 0x0C | 0x32 |   20 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-0/dimm-0
-                    DIMM21_Temp |     DIMM21 |  0x20  | 0x01 | 0x7E |   21 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-1/dimm-0
-                    DIMM21_Func |     DIMM21 |  0x20  | 0x0C | 0x33 |   21 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-1/dimm-0
-                    DIMM22_Temp |     DIMM22 |  0x20  | 0x01 | 0x7F |   22 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-2/dimm-0
-                    DIMM22_Func |     DIMM22 |  0x20  | 0x0C | 0x34 |   22 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-2/dimm-0
-                    DIMM23_Temp |     DIMM23 |  0x20  | 0x01 | 0x80 |   23 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-3/dimm-0
-                    DIMM23_Func |     DIMM23 |  0x20  | 0x0C | 0x35 |   23 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-3/dimm-0
-                   MEMBUF5_Temp |    MEMBUF5 |  0xD1  | 0x01 |  Err |    5 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/membuf-0
-                   MEMBUF5_Func |    MEMBUF5 |  0xD1  | 0x0C |  Err |    5 |    0 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/membuf-0
-                    DIMM24_Temp |     DIMM24 |  0x20  | 0x01 | 0x81 |   24 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-0/dimm-0
-                    DIMM24_Func |     DIMM24 |  0x20  | 0x0C | 0x36 |   24 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-0/dimm-0
-                    DIMM25_Temp |     DIMM25 |  0x20  | 0x01 | 0x82 |   25 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-1/dimm-0
-                    DIMM25_Func |     DIMM25 |  0x20  | 0x0C | 0x37 |   25 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-1/dimm-0
-                    DIMM26_Temp |     DIMM26 |  0x20  | 0x01 | 0x83 |   26 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-2/dimm-0
-                    DIMM26_Func |     DIMM26 |  0x20  | 0x0C | 0x38 |   26 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-2/dimm-0
-                    DIMM27_Temp |     DIMM27 |  0x20  | 0x01 | 0x84 |   27 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-3/dimm-0
-                    DIMM27_Func |     DIMM27 |  0x20  | 0x0C | 0x39 |   27 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-3/dimm-0
-                   MEMBUF6_Temp |    MEMBUF6 |  0xD1  | 0x01 |  Err |    6 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/membuf-0
-                   MEMBUF6_Func |    MEMBUF6 |  0xD1  | 0x0C |  Err |    6 |    0 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/membuf-0
-                    DIMM28_Temp |     DIMM28 |  0x20  | 0x01 | 0x85 |   28 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-0/dimm-0
-                    DIMM28_Func |     DIMM28 |  0x20  | 0x0C | 0x3A |   28 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-0/dimm-0
-                    DIMM29_Temp |     DIMM29 |  0x20  | 0x01 | 0x86 |   29 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-1/dimm-0
-                    DIMM29_Func |     DIMM29 |  0x20  | 0x0C | 0x3B |   29 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-1/dimm-0
-                    DIMM30_Temp |     DIMM30 |  0x20  | 0x01 | 0x87 |   30 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-2/dimm-0
-                    DIMM30_Func |     DIMM30 |  0x20  | 0x0C | 0x3C |   30 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-2/dimm-0
-                    DIMM31_Temp |     DIMM31 |  0x20  | 0x01 | 0x88 |   31 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-3/dimm-0
-                    DIMM31_Func |     DIMM31 |  0x20  | 0x0C | 0x3D |   31 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-3/dimm-0
-                   MEMBUF7_Temp |    MEMBUF7 |  0xD1  | 0x01 |  Err |    7 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/membuf-0
-                   MEMBUF7_Func |    MEMBUF7 |  0xD1  | 0x0C |  Err |    7 |    0 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/membuf-0
-                      CPU0_Temp |       CPU0 |  0x03  | 0x01 | 0x0B |    0 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc
-                      CPU0_Func |       CPU0 |  0x03  | 0x07 | 0x0C |    0 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc
-                     CORE0_Temp |      CORE0 |  0xD0  | 0x01 | 0x89 |    0 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-1/core-0
-                     CORE0_Func |      CORE0 |  0xD0  | 0x07 | 0x3E |    0 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-1/core-0
-                     CORE7_Temp |      CORE7 |  0xD0  | 0x01 | 0x90 |    7 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-10/core-0
-                     CORE7_Func |      CORE7 |  0xD0  | 0x07 | 0x45 |    7 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-10/core-0
-                     CORE8_Temp |      CORE8 |  0xD0  | 0x01 | 0x91 |    8 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-11/core-0
-                     CORE8_Func |      CORE8 |  0xD0  | 0x07 | 0x46 |    8 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-11/core-0
-                     CORE9_Temp |      CORE9 |  0xD0  | 0x01 | 0x92 |    9 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-12/core-0
-                     CORE9_Func |      CORE9 |  0xD0  | 0x07 | 0x47 |    9 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-12/core-0
-                    CORE10_Temp |     CORE10 |  0xD0  | 0x01 | 0x93 |   10 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-13/core-0
-                    CORE10_Func |     CORE10 |  0xD0  | 0x07 | 0x48 |   10 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-13/core-0
-                    CORE11_Temp |     CORE11 |  0xD0  | 0x01 | 0x94 |   11 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-14/core-0
-                    CORE11_Func |     CORE11 |  0xD0  | 0x07 | 0x49 |   11 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-14/core-0
-                     CORE1_Temp |      CORE1 |  0xD0  | 0x01 | 0x8A |    1 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-2/core-0
-                     CORE1_Func |      CORE1 |  0xD0  | 0x07 | 0x3F |    1 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-2/core-0
-                     CORE2_Temp |      CORE2 |  0xD0  | 0x01 | 0x8B |    2 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-3/core-0
-                     CORE2_Func |      CORE2 |  0xD0  | 0x07 | 0x40 |    2 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-3/core-0
-                     CORE3_Temp |      CORE3 |  0xD0  | 0x01 | 0x8C |    3 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-4/core-0
-                     CORE3_Func |      CORE3 |  0xD0  | 0x07 | 0x41 |    3 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-4/core-0
-                     CORE4_Temp |      CORE4 |  0xD0  | 0x01 | 0x8D |    4 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-5/core-0
-                     CORE4_Func |      CORE4 |  0xD0  | 0x07 | 0x42 |    4 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-5/core-0
-                     CORE5_Temp |      CORE5 |  0xD0  | 0x01 | 0x8E |    5 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-6/core-0
-                     CORE5_Func |      CORE5 |  0xD0  | 0x07 | 0x43 |    5 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-6/core-0
-                     CORE6_Temp |      CORE6 |  0xD0  | 0x01 | 0x8F |    6 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-9/core-0
-                     CORE6_Func |      CORE6 |  0xD0  | 0x07 | 0x44 |    6 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-9/core-0
-         OCC0_OCC_Active_Sensor |       OCC0 |  0xD2  | 0x07 | 0x08 |    0 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/occ-0
-                      CPU1_Temp |       CPU1 |  0x03  | 0x01 |  Err |    1 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc
-                      CPU1_Func |       CPU1 |  0x03  | 0x07 |  Err |    1 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc
-                    CORE12_Temp |     CORE12 |  0xD0  | 0x01 |  Err |   12 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-1/core-0
-                    CORE12_Func |     CORE12 |  0xD0  | 0x07 |  Err |   12 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-1/core-0
-                    CORE19_Temp |     CORE19 |  0xD0  | 0x01 |  Err |   19 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-10/core-0
-                    CORE19_Func |     CORE19 |  0xD0  | 0x07 |  Err |   19 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-10/core-0
-                    CORE20_Temp |     CORE20 |  0xD0  | 0x01 |  Err |   20 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-11/core-0
-                    CORE20_Func |     CORE20 |  0xD0  | 0x07 |  Err |   20 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-11/core-0
-                    CORE21_Temp |     CORE21 |  0xD0  | 0x01 |  Err |   21 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-12/core-0
-                    CORE21_Func |     CORE21 |  0xD0  | 0x07 |  Err |   21 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-12/core-0
-                    CORE22_Temp |     CORE22 |  0xD0  | 0x01 |  Err |   22 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-13/core-0
-                    CORE22_Func |     CORE22 |  0xD0  | 0x07 |  Err |   22 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-13/core-0
-                    CORE23_Temp |     CORE23 |  0xD0  | 0x01 |  Err |   23 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-14/core-0
-                    CORE23_Func |     CORE23 |  0xD0  | 0x07 |  Err |   23 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-14/core-0
-                    CORE13_Temp |     CORE13 |  0xD0  | 0x01 |  Err |   13 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-2/core-0
-                    CORE13_Func |     CORE13 |  0xD0  | 0x07 |  Err |   13 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-2/core-0
-                    CORE14_Temp |     CORE14 |  0xD0  | 0x01 |  Err |   14 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-3/core-0
-                    CORE14_Func |     CORE14 |  0xD0  | 0x07 |  Err |   14 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-3/core-0
-                    CORE15_Temp |     CORE15 |  0xD0  | 0x01 |  Err |   15 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-4/core-0
-                    CORE15_Func |     CORE15 |  0xD0  | 0x07 |  Err |   15 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-4/core-0
-                    CORE16_Temp |     CORE16 |  0xD0  | 0x01 |  Err |   16 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-5/core-0
-                    CORE16_Func |     CORE16 |  0xD0  | 0x07 |  Err |   16 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-5/core-0
-                    CORE17_Temp |     CORE17 |  0xD0  | 0x01 |  Err |   17 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-6/core-0
-                    CORE17_Func |     CORE17 |  0xD0  | 0x07 |  Err |   17 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-6/core-0
-                    CORE18_Temp |     CORE18 |  0xD0  | 0x01 |  Err |   18 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-9/core-0
-                    CORE18_Func |     CORE18 |  0xD0  | 0x07 |  Err |   18 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-9/core-0
-         OCC1_OCC_Active_Sensor |       OCC1 |  0xD2  | 0x07 |  Err |    1 |    0 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/occ-0
+                    Sensor Name |   FRU Name | Ent ID | Type |   ID | Inst |  FRU |       HUID | Target
+ ------------------------------ | ---------- | ------ | ---- | ---- | ---- | ---- | ---------- | ----------
+              SYS0_System_Event |       SYS0 |  0x01  | 0x12 | 0x61 |    0 |   47 |            | /sys-0
+               SYS0_Host_Status |       SYS0 |  0x23  | 0x22 | 0x04 |    0 |   47 |            | /sys-0
+    SYS0_Firmware_Boot_Progress |       SYS0 |  0x22  | 0x0F | 0x05 |    0 |   47 |            | /sys-0
+         SYS0_PCIE_Link_Present |       SYS0 |  0x23  | 0xC4 | 0xB6 |    0 |   47 |            | /sys-0
+                   SYS0_OS_Boot |       SYS0 |  0x23  | 0x1F | 0xB5 |    0 |   47 |            | /sys-0
+                 SYS0_Power_Cap |       SYS0 |  0x17  | 0xC2 | 0xB3 |    0 |   47 |            | /sys-0
+                SYS0_Boot_count |       SYS0 |  0x22  | 0xC3 | 0x5F |    0 |   47 |            | /sys-0
+        SYS0_Power_Limit_Active |       SYS0 |  0x15  | 0xC6 | 0x62 |    0 |   47 |            | /sys-0
+        SYS0_PS_Derating_Factor |       SYS0 |  0x15  | 0xC8 | 0xB4 |    0 |   47 |            | /sys-0
+                      SYS0_Freq |       SYS0 |  0x08  | 0xC1 | 0x5E |    0 |   47 |            | /sys-0
+             Memory_Proc0_Power |            |  0xD7  | 0xC2 | 0xAC |   11 |    0 |            | /sys-0
+             Memory_Proc1_Power |            |  0xD7  | 0xC2 | 0xAD |   12 |    0 |            | /sys-0
+             Memory_Proc2_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+             Memory_Proc3_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                    Proc0_Power |            |  0xD7  | 0xC2 | 0xA2 |    1 |    0 |            | /sys-0
+                    Proc1_Power |            |  0xD7  | 0xC2 | 0xA3 |    2 |    0 |            | /sys-0
+                    Proc2_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                    Proc3_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+               PCIE_Proc0_Power |            |  0xD7  | 0xC2 | 0xA6 |    5 |    0 |            | /sys-0
+               PCIE_Proc1_Power |            |  0xD7  | 0xC2 | 0xA7 |    6 |    0 |            | /sys-0
+               PCIE_Proc2_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+               PCIE_Proc3_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                     IO_A_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                     IO_B_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                     IO_C_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                    Fan_Power_A |            |  0xD7  | 0xC2 | 0xB0 |   15 |    0 |            | /sys-0
+                    Fan_Power_B |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                Storage_Power_A |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                Storage_Power_B |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+             Total_System_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+             Memory_Cache_Power |            |  0xD7  | 0xC2 | 0xAB |   10 |    0 |            | /sys-0
+           Memory_Proc0_0_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+           Memory_Proc0_1_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+           Memory_Proc0_2_Power |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                       12VSense |            |  0xD7  | 0xC2 | 0xA1 |    0 |    0 |            | /sys-0
+                    GroundSense |            |  0xD7  | 0xC2 |      |    0 |    0 |            | /sys-0
+                       GPUSense |            |  0xD7  | 0xC2 | 0xAA |    9 |    0 |            | /sys-0
+       PLANAR_Motherboard_Fault |     PLANAR |  0x07  | 0xC7 | 0x60 |    0 |    3 | 0x00020000 | /sys-0/node-0
+               PLANAR_Ref_Clock |     PLANAR |  0xD4  | 0xC7 | 0x63 |    0 |    3 | 0x00020000 | /sys-0/node-0
+               PLANAR_PCI_Clock |     PLANAR |  0xD5  | 0xC7 | 0x64 |    0 |    3 | 0x00020000 | /sys-0/node-0
+               PLANAR_TOD_Clock |     PLANAR |  0xD6  | 0xC7 | 0xB1 |    0 |    3 | 0x00020000 | /sys-0/node-0
+              PLANAR_APSS_Fault |     PLANAR |  0xD7  | 0xC7 | 0xB2 |    0 |    3 | 0x00020000 | /sys-0/node-0
+                     DIMM0_Temp |      DIMM0 |  0x20  | 0x01 | 0x69 |    0 |   12 | 0x00030004 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-0/dimm-0
+                     DIMM0_Func |      DIMM0 |  0x20  | 0x0C | 0x1E |    0 |   12 | 0x00030004 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-0/dimm-0
+                     DIMM1_Temp |      DIMM1 |  0x20  | 0x01 | 0x6A |    1 |   13 | 0x00030005 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-1/dimm-0
+                     DIMM1_Func |      DIMM1 |  0x20  | 0x0C | 0x1F |    1 |   13 | 0x00030005 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-1/dimm-0
+                     DIMM2_Temp |      DIMM2 |  0x20  | 0x01 | 0x6B |    2 |   14 | 0x00030006 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-2/dimm-0
+                     DIMM2_Func |      DIMM2 |  0x20  | 0x0C | 0x20 |    2 |   14 | 0x00030006 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-2/dimm-0
+                     DIMM3_Temp |      DIMM3 |  0x20  | 0x01 | 0x6C |    3 |   15 | 0x00030007 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-3/dimm-0
+                     DIMM3_Func |      DIMM3 |  0x20  | 0x0C | 0x21 |    3 |   15 | 0x00030007 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/dimmconn-3/dimm-0
+                   MEMBUF0_Temp |    MEMBUF0 |  0xD1  | 0x01 | 0x65 |    0 |    4 | 0x00040001 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/membuf-0
+                   MEMBUF0_Func |    MEMBUF0 |  0xD1  | 0x0C | 0x56 |    0 |    4 | 0x00040001 | /sys-0/node-0/ponderosa-0/birchconn-0/birch-0/membuf-0
+                     DIMM4_Temp |      DIMM4 |  0x20  | 0x01 | 0x6D |    4 |   16 | 0x00030000 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-0/dimm-0
+                     DIMM4_Func |      DIMM4 |  0x20  | 0x0C | 0x22 |    4 |   16 | 0x00030000 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-0/dimm-0
+                     DIMM5_Temp |      DIMM5 |  0x20  | 0x01 | 0x6E |    5 |   17 | 0x00030001 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-1/dimm-0
+                     DIMM5_Func |      DIMM5 |  0x20  | 0x0C | 0x23 |    5 |   17 | 0x00030001 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-1/dimm-0
+                     DIMM6_Temp |      DIMM6 |  0x20  | 0x01 | 0x6F |    6 |   18 | 0x00030002 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-2/dimm-0
+                     DIMM6_Func |      DIMM6 |  0x20  | 0x0C | 0x24 |    6 |   18 | 0x00030002 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-2/dimm-0
+                     DIMM7_Temp |      DIMM7 |  0x20  | 0x01 | 0x70 |    7 |   19 | 0x00030003 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-3/dimm-0
+                     DIMM7_Func |      DIMM7 |  0x20  | 0x0C | 0x25 |    7 |   19 | 0x00030003 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/dimmconn-3/dimm-0
+                   MEMBUF1_Temp |    MEMBUF1 |  0xD1  | 0x01 | 0x66 |    1 |    5 | 0x00040000 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/membuf-0
+                   MEMBUF1_Func |    MEMBUF1 |  0xD1  | 0x0C | 0x57 |    1 |    5 | 0x00040000 | /sys-0/node-0/ponderosa-0/birchconn-1/birch-0/membuf-0
+                     DIMM8_Temp |      DIMM8 |  0x20  | 0x01 | 0x71 |    8 |   20 | 0x00030008 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-0/dimm-0
+                     DIMM8_Func |      DIMM8 |  0x20  | 0x0C | 0x26 |    8 |   20 | 0x00030008 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-0/dimm-0
+                     DIMM9_Temp |      DIMM9 |  0x20  | 0x01 | 0x72 |    9 |   21 | 0x00030009 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-1/dimm-0
+                     DIMM9_Func |      DIMM9 |  0x20  | 0x0C | 0x27 |    9 |   21 | 0x00030009 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-1/dimm-0
+                    DIMM10_Temp |     DIMM10 |  0x20  | 0x01 | 0x73 |   10 |   22 | 0x0003000A | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-2/dimm-0
+                    DIMM10_Func |     DIMM10 |  0x20  | 0x0C | 0x28 |   10 |   22 | 0x0003000A | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-2/dimm-0
+                    DIMM11_Temp |     DIMM11 |  0x20  | 0x01 | 0x74 |   11 |   23 | 0x0003000B | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-3/dimm-0
+                    DIMM11_Func |     DIMM11 |  0x20  | 0x0C | 0x29 |   11 |   23 | 0x0003000B | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/dimmconn-3/dimm-0
+                   MEMBUF2_Temp |    MEMBUF2 |  0xD1  | 0x01 | 0x67 |    2 |    6 | 0x00040002 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/membuf-0
+                   MEMBUF2_Func |    MEMBUF2 |  0xD1  | 0x0C | 0x58 |    2 |    6 | 0x00040002 | /sys-0/node-0/ponderosa-0/birchconn-2/birch-0/membuf-0
+                    DIMM12_Temp |     DIMM12 |  0x20  | 0x01 | 0x75 |   12 |   24 | 0x0003000C | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-0/dimm-0
+                    DIMM12_Func |     DIMM12 |  0x20  | 0x0C | 0x2A |   12 |   24 | 0x0003000C | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-0/dimm-0
+                    DIMM13_Temp |     DIMM13 |  0x20  | 0x01 | 0x76 |   13 |   25 | 0x0003000D | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-1/dimm-0
+                    DIMM13_Func |     DIMM13 |  0x20  | 0x0C | 0x2B |   13 |   25 | 0x0003000D | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-1/dimm-0
+                    DIMM14_Temp |     DIMM14 |  0x20  | 0x01 | 0x77 |   14 |   26 | 0x0003000E | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-2/dimm-0
+                    DIMM14_Func |     DIMM14 |  0x20  | 0x0C | 0x2C |   14 |   26 | 0x0003000E | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-2/dimm-0
+                    DIMM15_Temp |     DIMM15 |  0x20  | 0x01 | 0x78 |   15 |   27 | 0x0003000F | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-3/dimm-0
+                    DIMM15_Func |     DIMM15 |  0x20  | 0x0C | 0x2D |   15 |   27 | 0x0003000F | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/dimmconn-3/dimm-0
+                   MEMBUF3_Temp |    MEMBUF3 |  0xD1  | 0x01 | 0x68 |    3 |    7 | 0x00040003 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/membuf-0
+                   MEMBUF3_Func |    MEMBUF3 |  0xD1  | 0x0C | 0x59 |    3 |    7 | 0x00040003 | /sys-0/node-0/ponderosa-0/birchconn-3/birch-0/membuf-0
+                    DIMM16_Temp |     DIMM16 |  0x20  | 0x01 | 0x79 |   16 |   28 | 0x00030014 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-0/dimm-0
+                    DIMM16_Func |     DIMM16 |  0x20  | 0x0C | 0x2E |   16 |   28 | 0x00030014 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-0/dimm-0
+                    DIMM17_Temp |     DIMM17 |  0x20  | 0x01 | 0x7A |   17 |   29 | 0x00030015 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-1/dimm-0
+                    DIMM17_Func |     DIMM17 |  0x20  | 0x0C | 0x2F |   17 |   29 | 0x00030015 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-1/dimm-0
+                    DIMM18_Temp |     DIMM18 |  0x20  | 0x01 | 0x7B |   18 |   30 | 0x00030016 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-2/dimm-0
+                    DIMM18_Func |     DIMM18 |  0x20  | 0x0C | 0x30 |   18 |   30 | 0x00030016 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-2/dimm-0
+                    DIMM19_Temp |     DIMM19 |  0x20  | 0x01 | 0x7C |   19 |   31 | 0x00030017 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-3/dimm-0
+                    DIMM19_Func |     DIMM19 |  0x20  | 0x0C | 0x31 |   19 |   31 | 0x00030017 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/dimmconn-3/dimm-0
+                   MEMBUF4_Temp |    MEMBUF4 |  0xD1  | 0x01 | 0x69 |    4 |    8 | 0x00040005 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/membuf-0
+                   MEMBUF4_Func |    MEMBUF4 |  0xD1  | 0x0C | 0x5A |    4 |    8 | 0x00040005 | /sys-0/node-0/ponderosa-0/birchconn-4/birch-0/membuf-0
+                    DIMM20_Temp |     DIMM20 |  0x20  | 0x01 | 0x7D |   20 |   32 | 0x00030010 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-0/dimm-0
+                    DIMM20_Func |     DIMM20 |  0x20  | 0x0C | 0x32 |   20 |   32 | 0x00030010 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-0/dimm-0
+                    DIMM21_Temp |     DIMM21 |  0x20  | 0x01 | 0x7E |   21 |   33 | 0x00030011 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-1/dimm-0
+                    DIMM21_Func |     DIMM21 |  0x20  | 0x0C | 0x33 |   21 |   33 | 0x00030011 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-1/dimm-0
+                    DIMM22_Temp |     DIMM22 |  0x20  | 0x01 | 0x7F |   22 |   34 | 0x00030012 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-2/dimm-0
+                    DIMM22_Func |     DIMM22 |  0x20  | 0x0C | 0x34 |   22 |   34 | 0x00030012 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-2/dimm-0
+                    DIMM23_Temp |     DIMM23 |  0x20  | 0x01 | 0x80 |   23 |   35 | 0x00030013 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-3/dimm-0
+                    DIMM23_Func |     DIMM23 |  0x20  | 0x0C | 0x35 |   23 |   35 | 0x00030013 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/dimmconn-3/dimm-0
+                   MEMBUF5_Temp |    MEMBUF5 |  0xD1  | 0x01 | 0x6A |    5 |    9 | 0x00040004 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/membuf-0
+                   MEMBUF5_Func |    MEMBUF5 |  0xD1  | 0x0C | 0x5B |    5 |    9 | 0x00040004 | /sys-0/node-0/ponderosa-0/birchconn-5/birch-0/membuf-0
+                    DIMM24_Temp |     DIMM24 |  0x20  | 0x01 | 0x81 |   24 |   36 | 0x00030018 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-0/dimm-0
+                    DIMM24_Func |     DIMM24 |  0x20  | 0x0C | 0x36 |   24 |   36 | 0x00030018 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-0/dimm-0
+                    DIMM25_Temp |     DIMM25 |  0x20  | 0x01 | 0x82 |   25 |   37 | 0x00030019 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-1/dimm-0
+                    DIMM25_Func |     DIMM25 |  0x20  | 0x0C | 0x37 |   25 |   37 | 0x00030019 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-1/dimm-0
+                    DIMM26_Temp |     DIMM26 |  0x20  | 0x01 | 0x83 |   26 |   38 | 0x0003001A | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-2/dimm-0
+                    DIMM26_Func |     DIMM26 |  0x20  | 0x0C | 0x38 |   26 |   38 | 0x0003001A | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-2/dimm-0
+                    DIMM27_Temp |     DIMM27 |  0x20  | 0x01 | 0x84 |   27 |   39 | 0x0003001B | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-3/dimm-0
+                    DIMM27_Func |     DIMM27 |  0x20  | 0x0C | 0x39 |   27 |   39 | 0x0003001B | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/dimmconn-3/dimm-0
+                   MEMBUF6_Temp |    MEMBUF6 |  0xD1  | 0x01 | 0x6B |    6 |   10 | 0x00040006 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/membuf-0
+                   MEMBUF6_Func |    MEMBUF6 |  0xD1  | 0x0C | 0x5C |    6 |   10 | 0x00040006 | /sys-0/node-0/ponderosa-0/birchconn-6/birch-0/membuf-0
+                    DIMM28_Temp |     DIMM28 |  0x20  | 0x01 | 0x85 |   28 |   40 | 0x0003001C | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-0/dimm-0
+                    DIMM28_Func |     DIMM28 |  0x20  | 0x0C | 0x3A |   28 |   40 | 0x0003001C | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-0/dimm-0
+                    DIMM29_Temp |     DIMM29 |  0x20  | 0x01 | 0x86 |   29 |   41 | 0x0003001D | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-1/dimm-0
+                    DIMM29_Func |     DIMM29 |  0x20  | 0x0C | 0x3B |   29 |   41 | 0x0003001D | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-1/dimm-0
+                    DIMM30_Temp |     DIMM30 |  0x20  | 0x01 | 0x87 |   30 |   42 | 0x0003001E | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-2/dimm-0
+                    DIMM30_Func |     DIMM30 |  0x20  | 0x0C | 0x3C |   30 |   42 | 0x0003001E | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-2/dimm-0
+                    DIMM31_Temp |     DIMM31 |  0x20  | 0x01 | 0x88 |   31 |   43 | 0x0003001F | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-3/dimm-0
+                    DIMM31_Func |     DIMM31 |  0x20  | 0x0C | 0x3D |   31 |   43 | 0x0003001F | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/dimmconn-3/dimm-0
+                   MEMBUF7_Temp |    MEMBUF7 |  0xD1  | 0x01 | 0x6C |    7 |   11 | 0x00040007 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/membuf-0
+                   MEMBUF7_Func |    MEMBUF7 |  0xD1  | 0x0C | 0x5D |    7 |   11 | 0x00040007 | /sys-0/node-0/ponderosa-0/birchconn-7/birch-0/membuf-0
+                      CPU0_Temp |       CPU0 |  0x03  | 0x01 | 0x0B |    0 |    1 | 0x00050000 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc
+                      CPU0_Func |       CPU0 |  0x03  | 0x07 | 0x0C |    0 |    1 | 0x00050000 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc
+                     CORE0_Temp |      CORE0 |  0xD0  | 0x01 | 0x89 |    0 |    0 | 0x00070000 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-1/core-0
+                     CORE0_Func |      CORE0 |  0xD0  | 0x07 | 0x3E |    0 |    0 | 0x00070000 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-1/core-0
+                     CORE7_Temp |      CORE7 |  0xD0  | 0x01 | 0x90 |    7 |    0 | 0x00070007 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-10/core-0
+                     CORE7_Func |      CORE7 |  0xD0  | 0x07 | 0x45 |    7 |    0 | 0x00070007 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-10/core-0
+                     CORE8_Temp |      CORE8 |  0xD0  | 0x01 | 0x91 |    8 |    0 | 0x00070008 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-11/core-0
+                     CORE8_Func |      CORE8 |  0xD0  | 0x07 | 0x46 |    8 |    0 | 0x00070008 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-11/core-0
+                     CORE9_Temp |      CORE9 |  0xD0  | 0x01 | 0x92 |    9 |    0 | 0x00070009 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-12/core-0
+                     CORE9_Func |      CORE9 |  0xD0  | 0x07 | 0x47 |    9 |    0 | 0x00070009 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-12/core-0
+                    CORE10_Temp |     CORE10 |  0xD0  | 0x01 | 0x93 |   10 |    0 | 0x0007000A | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-13/core-0
+                    CORE10_Func |     CORE10 |  0xD0  | 0x07 | 0x48 |   10 |    0 | 0x0007000A | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-13/core-0
+                    CORE11_Temp |     CORE11 |  0xD0  | 0x01 | 0x94 |   11 |    0 | 0x0007000B | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-14/core-0
+                    CORE11_Func |     CORE11 |  0xD0  | 0x07 | 0x49 |   11 |    0 | 0x0007000B | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-14/core-0
+                     CORE1_Temp |      CORE1 |  0xD0  | 0x01 | 0x8A |    1 |    0 | 0x00070001 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-2/core-0
+                     CORE1_Func |      CORE1 |  0xD0  | 0x07 | 0x3F |    1 |    0 | 0x00070001 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-2/core-0
+                     CORE2_Temp |      CORE2 |  0xD0  | 0x01 | 0x8B |    2 |    0 | 0x00070002 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-3/core-0
+                     CORE2_Func |      CORE2 |  0xD0  | 0x07 | 0x40 |    2 |    0 | 0x00070002 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-3/core-0
+                     CORE3_Temp |      CORE3 |  0xD0  | 0x01 | 0x8C |    3 |    0 | 0x00070003 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-4/core-0
+                     CORE3_Func |      CORE3 |  0xD0  | 0x07 | 0x41 |    3 |    0 | 0x00070003 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-4/core-0
+                     CORE4_Temp |      CORE4 |  0xD0  | 0x01 | 0x8D |    4 |    0 | 0x00070004 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-5/core-0
+                     CORE4_Func |      CORE4 |  0xD0  | 0x07 | 0x42 |    4 |    0 | 0x00070004 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-5/core-0
+                     CORE5_Temp |      CORE5 |  0xD0  | 0x01 | 0x8E |    5 |    0 | 0x00070005 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-6/core-0
+                     CORE5_Func |      CORE5 |  0xD0  | 0x07 | 0x43 |    5 |    0 | 0x00070005 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-6/core-0
+                     CORE6_Temp |      CORE6 |  0xD0  | 0x01 | 0x8F |    6 |    0 | 0x00070006 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-9/core-0
+                     CORE6_Func |      CORE6 |  0xD0  | 0x07 | 0x44 |    6 |    0 | 0x00070006 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/ex-9/core-0
+         OCC0_OCC_Active_Sensor |       OCC0 |  0xD2  | 0x07 | 0x08 |    0 |    1 | 0x00130000 | /sys-0/node-0/ponderosa-0/proc_socket-0/module-0/proc/occ-0
+                      CPU1_Temp |       CPU1 |  0x03  | 0x01 | 0x0D |    1 |    2 | 0x00050001 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc
+                      CPU1_Func |       CPU1 |  0x03  | 0x07 | 0x0E |    1 |    2 | 0x00050001 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc
+                    CORE12_Temp |     CORE12 |  0xD0  | 0x01 | 0x95 |   12 |    0 | 0x0007000C | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-1/core-0
+                    CORE12_Func |     CORE12 |  0xD0  | 0x07 | 0x4A |   12 |    0 | 0x0007000C | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-1/core-0
+                    CORE19_Temp |     CORE19 |  0xD0  | 0x01 | 0x9C |   19 |    0 | 0x00070013 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-10/core-0
+                    CORE19_Func |     CORE19 |  0xD0  | 0x07 | 0x51 |   19 |    0 | 0x00070013 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-10/core-0
+                    CORE20_Temp |     CORE20 |  0xD0  | 0x01 | 0x9D |   20 |    0 | 0x00070014 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-11/core-0
+                    CORE20_Func |     CORE20 |  0xD0  | 0x07 | 0x52 |   20 |    0 | 0x00070014 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-11/core-0
+                    CORE21_Temp |     CORE21 |  0xD0  | 0x01 | 0x9E |   21 |    0 | 0x00070015 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-12/core-0
+                    CORE21_Func |     CORE21 |  0xD0  | 0x07 | 0x53 |   21 |    0 | 0x00070015 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-12/core-0
+                    CORE22_Temp |     CORE22 |  0xD0  | 0x01 | 0x9F |   22 |    0 | 0x00070016 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-13/core-0
+                    CORE22_Func |     CORE22 |  0xD0  | 0x07 | 0x54 |   22 |    0 | 0x00070016 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-13/core-0
+                    CORE23_Temp |     CORE23 |  0xD0  | 0x01 | 0xA0 |   23 |    0 | 0x00070017 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-14/core-0
+                    CORE23_Func |     CORE23 |  0xD0  | 0x07 | 0x55 |   23 |    0 | 0x00070017 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-14/core-0
+                    CORE13_Temp |     CORE13 |  0xD0  | 0x01 | 0x96 |   13 |    0 | 0x0007000D | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-2/core-0
+                    CORE13_Func |     CORE13 |  0xD0  | 0x07 | 0x4B |   13 |    0 | 0x0007000D | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-2/core-0
+                    CORE14_Temp |     CORE14 |  0xD0  | 0x01 | 0x97 |   14 |    0 | 0x0007000E | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-3/core-0
+                    CORE14_Func |     CORE14 |  0xD0  | 0x07 | 0x4C |   14 |    0 | 0x0007000E | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-3/core-0
+                    CORE15_Temp |     CORE15 |  0xD0  | 0x01 | 0x98 |   15 |    0 | 0x0007000F | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-4/core-0
+                    CORE15_Func |     CORE15 |  0xD0  | 0x07 | 0x4D |   15 |    0 | 0x0007000F | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-4/core-0
+                    CORE16_Temp |     CORE16 |  0xD0  | 0x01 | 0x99 |   16 |    0 | 0x00070010 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-5/core-0
+                    CORE16_Func |     CORE16 |  0xD0  | 0x07 | 0x4E |   16 |    0 | 0x00070010 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-5/core-0
+                    CORE17_Temp |     CORE17 |  0xD0  | 0x01 | 0x9A |   17 |    0 | 0x00070011 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-6/core-0
+                    CORE17_Func |     CORE17 |  0xD0  | 0x07 | 0x4F |   17 |    0 | 0x00070011 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-6/core-0
+                    CORE18_Temp |     CORE18 |  0xD0  | 0x01 | 0x9B |   18 |    0 | 0x00070012 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-9/core-0
+                    CORE18_Func |     CORE18 |  0xD0  | 0x07 | 0x50 |   18 |    0 | 0x00070012 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/ex-9/core-0
+         OCC1_OCC_Active_Sensor |       OCC1 |  0xD2  | 0x07 | 0x09 |    1 |    2 | 0x00130001 | /sys-0/node-0/ponderosa-0/proc_socket-1/module-1/proc/occ-0

--- a/firestone.xml
+++ b/firestone.xml
@@ -98,6 +98,10 @@
 		<value>0x00000080</value>
 		</enumerator>
 		<enumerator>
+		<name>UPDATE_BOTH_SIDES_OF_SBE</name>
+		<value>0x00040000</value>
+		</enumerator>
+		<enumerator>
 		<name>AVP_ENABLE</name>
 		<value>0x00000002</value>
 		</enumerator>
@@ -148,6 +152,33 @@
 		<enumerator>
 		<name>DISABLE_FABRIC_eREPAIR</name>
 		<value>0x00000800</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>NPU_MMIO_BAR_SIZE</id>
+		<enumerator>
+		<name>64_KB</name>
+		<value>0x0000000000010000</value>
+		</enumerator>
+		<enumerator>
+		<name>512_KB</name>
+		<value>0x0000000000080000</value>
+		</enumerator>
+		<enumerator>
+		<name>1_MB</name>
+		<value>0x0000000000100000</value>
+		</enumerator>
+		<enumerator>
+		<name>2_MB</name>
+		<value>0x0000000000200000</value>
+		</enumerator>
+		<enumerator>
+		<name>128_KB</name>
+		<value>0x0000000000020000</value>
+		</enumerator>
+		<enumerator>
+		<name>256_KB</name>
+		<value>0x0000000000040000</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -270,83 +301,114 @@
 	<id>SENSOR_NAME</id>
 		<enumerator>
 		<name>PCI_ACTIVE</name>
-		<value>0x0c00</value>
+		<value>0xC423</value>
 		</enumerator>
 		<enumerator>
 		<name>STATE</name>
 		<value>0x0500</value>
 		</enumerator>
 		<enumerator>
-		<name>SYSTEM_POWER_CAP</name>
-		<value>0x0b00</value>
+		<name>DIMM_TEMP</name>
+		<value>0x0120</value>
 		</enumerator>
 		<enumerator>
-		<name>VOLTAGE</name>
-		<value>0x0200</value>
-		</enumerator>
-		<enumerator>
-		<name>APSS_CHANNEL</name>
-		<value>0x1100</value>
+		<name>CORE_FREQ</name>
+		<value>0xC1D0</value>
 		</enumerator>
 		<enumerator>
 		<name>FAULT</name>
-		<value>0x1000</value>
-		</enumerator>
-		<enumerator>
-		<name>BOOT_WATCHDOG</name>
-		<value>0x0d00</value>
+		<value>0xC700</value>
 		</enumerator>
 		<enumerator>
 		<name>OCC_ACTIVE</name>
-		<value>0x0A00</value>
+		<value>0x07D2</value>
+		</enumerator>
+		<enumerator>
+		<name>BACKPLANE_FAULT</name>
+		<value>0xC707</value>
 		</enumerator>
 		<enumerator>
 		<name>APSS_FAULT</name>
-		<value>0x1010</value>
+		<value>0xC7D7</value>
 		</enumerator>
 		<enumerator>
 		<name>FW_BOOT_PROGRESS</name>
-		<value>0x0900</value>
+		<value>0x0F22</value>
 		</enumerator>
 		<enumerator>
-		<name>REF_CLOCK_FAULT</name>
-		<value>0x101A</value>
+		<name>CORE_STATE</name>
+		<value>0x07D0</value>
+		</enumerator>
+		<enumerator>
+		<name>PROC_TEMP</name>
+		<value>0x0103</value>
 		</enumerator>
 		<enumerator>
 		<name>REBOOT_COUNT</name>
-		<value>0x0e00</value>
+		<value>0xC322</value>
 		</enumerator>
 		<enumerator>
-		<name>POWER_UNIT</name>
-		<value>0x0600</value>
+		<name>MEMBUF_STATE</name>
+		<value>0x0CD1</value>
 		</enumerator>
 		<enumerator>
 		<name>PCI_CLOCK_FAULT</name>
-		<value>0x101B</value>
+		<value>0xC7D5</value>
 		</enumerator>
 		<enumerator>
-		<name>INTRUSION</name>
-		<value>0x0400</value>
+		<name>MEMBUF_TEMP</name>
+		<value>0x01D1</value>
 		</enumerator>
 		<enumerator>
-		<name>TOD_CLOCK_FAULT</name>
-		<value>0x1017</value>
-		</enumerator>
-		<enumerator>
-		<name>CURRENT</name>
-		<value>0x0300</value>
+		<name>PROC_STATE</name>
+		<value>0x0703</value>
 		</enumerator>
 		<enumerator>
 		<name>HOST_STATUS</name>
-		<value>0x0800</value>
-		</enumerator>
-		<enumerator>
-		<name>TEMPERATURE</name>
-		<value>0x0100</value>
+		<value>0x2223</value>
 		</enumerator>
 		<enumerator>
 		<name>OS_BOOT</name>
-		<value>0x0700</value>
+		<value>0x1F23</value>
+		</enumerator>
+		<enumerator>
+		<name>APSS_CHANNEL</name>
+		<value>0xC2D7</value>
+		</enumerator>
+		<enumerator>
+		<name>CORE_TEMP</name>
+		<value>0x01D0</value>
+		</enumerator>
+		<enumerator>
+		<name>SYSTEM_EVENT</name>
+		<value>0x1201</value>
+		</enumerator>
+		<enumerator>
+		<name>REF_CLOCK_FAULT</name>
+		<value>0xC7D4</value>
+		</enumerator>
+		<enumerator>
+		<name>DIMM_STATE</name>
+		<value>0x0C20</value>
+		</enumerator>
+		<enumerator>
+		<name>DERATING_FACTOR</name>
+		<value>0xC815</value>
+		</enumerator>
+		<enumerator>
+		<name>TOD_CLOCK_FAULT</name>
+		<value>0xC7D6</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>NPU_MMIO_BAR_ENABLE</id>
+		<enumerator>
+		<name>ENABLE</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>DISABLE</name>
+		<value>0</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -790,6 +852,25 @@
 		</enumerator>
 </enumerationType>
 <enumerationType>
+	<id>HIDDEN_ERRLOGS_ENABLE</id>
+		<enumerator>
+		<name>ALLOW_RECOVERED</name>
+		<value>2</value>
+		</enumerator>
+		<enumerator>
+		<name>ALLOW_ALL_LOGS</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>ALLOW_INFORMATIONAL</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>NO_HIDDEN_LOGS</name>
+		<value>0</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
 	<id>PROC_X_BUS_WIDTH</id>
 		<enumerator>
 		<name>W8BYTE</name>
@@ -866,16 +947,16 @@
 		<value>0</value>
 		</enumerator>
 		<enumerator>
+		<name>MEMBUF</name>
+		<value>0xD1</value>
+		</enumerator>
+		<enumerator>
 		<name>POWER_MGMT</name>
 		<value>0x15</value>
 		</enumerator>
 		<enumerator>
 		<name>MEMORY_DEVICE</name>
 		<value>0x20</value>
-		</enumerator>
-		<enumerator>
-		<name>CENTAUR</name>
-		<value>0xD1</value>
 		</enumerator>
 </enumerationType>
 <enumerationType>
@@ -1148,12 +1229,24 @@
 		<value>0x07</value>
 		</enumerator>
 		<enumerator>
-		<name>POWER_UNIT</name>
-		<value>0x09</value>
+		<name>PWR_LIMIT_ACTIVE</name>
+		<value>0xC4</value>
 		</enumerator>
 		<enumerator>
-		<name>VOLTAGE</name>
-		<value>0x02</value>
+		<name>POWER</name>
+		<value>0xC2</value>
+		</enumerator>
+		<enumerator>
+		<name>BOOT_COUNT</name>
+		<value>0xC3</value>
+		</enumerator>
+		<enumerator>
+		<name>PCI_LINK_PRES</name>
+		<value>0xC4</value>
+		</enumerator>
+		<enumerator>
+		<name>FREQ</name>
+		<value>0xC1</value>
 		</enumerator>
 		<enumerator>
 		<name>APCI_POWER_STATE</name>
@@ -1164,24 +1257,20 @@
 		<value>0x0c</value>
 		</enumerator>
 		<enumerator>
-		<name>SYSTEM_FIRMWARE_PROGRESS</name>
-		<value>0x0F</value>
+		<name>FAULT</name>
+		<value>0xC7</value>
 		</enumerator>
 		<enumerator>
-		<name>PHYSICAL_SECURITY</name>
-		<value>0x05</value>
+		<name>SYS_EVENT</name>
+		<value>0x12</value>
 		</enumerator>
 		<enumerator>
 		<name>NA</name>
 		<value>0</value>
 		</enumerator>
 		<enumerator>
-		<name>CURRENT</name>
-		<value>0x03</value>
-		</enumerator>
-		<enumerator>
-		<name>REBOOT_COUNT</name>
-		<value>0xC0</value>
+		<name>SYS_FW_PROGRESS</name>
+		<value>0x0F</value>
 		</enumerator>
 		<enumerator>
 		<name>OS_BOOT</name>
@@ -1189,6 +1278,40 @@
 		</enumerator>
 		<enumerator>
 		<name>TEMPERATURE</name>
+		<value>0x01</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>MRW_NEST_CAPABLE_FREQUENCIES_SYS</id>
+		<enumerator>
+		<name>2000_MHZ</name>
+		<value>1</value>
+		</enumerator>
+		<enumerator>
+		<name>2000_MHZ_OR_2400_MHZ</name>
+		<value>3</value>
+		</enumerator>
+		<enumerator>
+		<name>UNSUPPORTED_FREQ</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>2400_MHZ</name>
+		<value>2</value>
+		</enumerator>
+</enumerationType>
+<enumerationType>
+	<id>SUPPORTED_HOT_PLUG</id>
+		<enumerator>
+		<name>PCA9551</name>
+		<value>0x02</value>
+		</enumerator>
+		<enumerator>
+		<name>NA</name>
+		<value>0</value>
+		</enumerator>
+		<enumerator>
+		<name>MAX5961</name>
 		<value>0x01</value>
 		</enumerator>
 </enumerationType>
@@ -2967,7 +3090,7 @@
 	</property>
 	<property>
 	<id>FRU_ID</id>
-	<value>51</value>
+	<value>47</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -5037,6 +5160,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>BMC_FRU_ID</id>
+		<default>47</default>
+	</attribute>
+	<attribute>
 		<id>BOOT_FREQ_MHZ</id>
 		<default>2400</default>
 	</attribute>
@@ -5102,10 +5229,6 @@
 	<attribute>
 		<id>FRU_ID</id>
 		<default></default>
-	</attribute>
-	<attribute>
-		<id>BMC_FRU_ID</id>
-		<default>47</default>
 	</attribute>
 	<attribute>
 		<id>FRU_NAME</id>
@@ -5412,6 +5535,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SP_FUNCTIONS</id>
 		<default>
 				<field><id>baseServices</id><value>0</value></field>
@@ -5477,6 +5604,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NODE</default>
 	</attribute>
@@ -5540,6 +5671,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -6322,6 +6457,10 @@
 			</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -6351,6 +6490,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -6518,7 +6661,7 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
-    </attribute>
+	</attribute>
 	<attribute>
 		<id>MSS_INTERLEAVE_ENABLE</id>
 		<default>0xE</default>
@@ -6626,13 +6769,17 @@
 		<default>1,0x0003FFFE80000000,0x2000000,0x400000,0x0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>RNG_BASE_ADDR</id>
 		<default>1,0x0003FFFF40000000,0x4000,0x1000,0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
 		<default>PROC</default>
-    </attribute>
+	</attribute>
 </targetInstance>
 <targetInstance>
 	<id>ex-1</id>
@@ -6660,6 +6807,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -6701,6 +6852,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -6758,6 +6913,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -6813,6 +6972,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -6843,6 +7006,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -6877,6 +7044,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>EX</default>
 	</attribute>
@@ -6907,6 +7078,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -6941,6 +7116,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>EX</default>
 	</attribute>
@@ -6971,6 +7150,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7005,6 +7188,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>EX</default>
 	</attribute>
@@ -7035,6 +7222,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7069,6 +7260,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>EX</default>
 	</attribute>
@@ -7099,6 +7294,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7133,6 +7332,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>EX</default>
 	</attribute>
@@ -7163,6 +7366,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7196,6 +7403,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>PORE</default>
 	</attribute>
@@ -7227,6 +7438,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>CAPP</default>
 	</attribute>
@@ -7256,6 +7471,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7304,6 +7523,10 @@
 	<attribute>
 		<id>OCC_MASTER_CAPABLE</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7361,6 +7584,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -7396,6 +7623,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>PCI_CONFIGS</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7444,6 +7675,10 @@
 		000,010,001,011,111,101,110,100,
 		000,010,001,011,110,101,110,100
 		 </default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7502,6 +7737,10 @@
 	</attribute>
 	<attribute>
 		<id>PHB_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -7568,6 +7807,10 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -7619,6 +7862,10 @@
 		000,010,001,011,111,101,110,100,
 		000,010,001,011,000,010,001,011
 		 </default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7678,6 +7925,10 @@
 	<attribute>
 		<id>PHB_NUM</id>
 		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -7743,6 +7994,10 @@
 		<default>2</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -7782,6 +8037,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>ABUS</default>
 	</attribute>
@@ -7817,6 +8076,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>ABUS</default>
 	</attribute>
@@ -7850,6 +8113,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -7894,6 +8161,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -7944,6 +8215,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>M0 DMI C</default>
 	</attribute>
@@ -7992,6 +8267,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>M1 DMI D</default>
 	</attribute>
@@ -8038,6 +8317,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -8091,6 +8374,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSI</default>
 	</attribute>
@@ -8140,6 +8427,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSICM</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -8193,6 +8484,10 @@
 		<default>FSICM</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSI</default>
 	</attribute>
@@ -8242,6 +8537,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSICM</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -8295,6 +8594,10 @@
 		<default>FSICM</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSI</default>
 	</attribute>
@@ -8344,6 +8647,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>FSIM</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -8397,6 +8704,10 @@
 		<default>FSIM</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSI</default>
 	</attribute>
@@ -8448,6 +8759,10 @@
 		<default>FSIM</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSI</default>
 	</attribute>
@@ -8481,6 +8796,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -8526,6 +8845,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -8569,6 +8892,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -8602,6 +8929,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -8641,6 +8972,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -8699,6 +9034,10 @@
 	</attribute>
 	<attribute>
 		<id>PHB_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -8765,6 +9104,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -8825,6 +9168,10 @@
 	</attribute>
 	<attribute>
 		<id>PHB_NUM</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -8891,6 +9238,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -8930,6 +9281,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>XBUS</default>
 	</attribute>
@@ -8963,6 +9318,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -9000,6 +9359,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>XBUS</default>
 	</attribute>
@@ -9033,6 +9396,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -9077,6 +9444,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -9127,6 +9498,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>M1 DMI B</default>
 	</attribute>
@@ -9175,6 +9550,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>M0 DMI C</default>
 	</attribute>
@@ -9221,6 +9600,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -9282,6 +9665,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -9335,6 +9722,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -9471,6 +9862,10 @@
 			</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -9503,6 +9898,10 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -9532,6 +9931,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -9575,6 +9978,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -9800,6 +10207,10 @@
 	<hidden_child_id>membuf_temp_sensor</hidden_child_id>
 	<hidden_child_id>membuf_func_sensor</hidden_child_id>
 	<attribute>
+		<id>CENTAUR_ECID_FRU_ID</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
 		<id>CHIP_ID</id>
 		<default></default>
 	</attribute>
@@ -9852,6 +10263,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>MEMBUF</default>
 	</attribute>
@@ -9887,6 +10302,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default></default>
 	</attribute>
@@ -9916,6 +10335,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -9955,6 +10378,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -9998,6 +10425,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -10047,6 +10478,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -10092,6 +10527,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -10141,6 +10580,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -10184,6 +10627,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>MBA</default>
 	</attribute>
@@ -10225,6 +10672,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -10274,6 +10725,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -10319,6 +10774,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -10368,6 +10827,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default></default>
 	</attribute>
@@ -10415,6 +10878,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -10456,6 +10923,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -10505,6 +10976,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSI</default>
 	</attribute>
@@ -10544,6 +11019,10 @@
 		<default>VDDR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -10581,6 +11060,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -10638,6 +11121,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -10693,6 +11180,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -10722,6 +11213,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -10772,6 +11267,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>DIMM</default>
 	</attribute>
@@ -10805,6 +11304,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -10861,6 +11364,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default></default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -10930,6 +11437,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -10985,6 +11496,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -11015,6 +11530,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -11049,6 +11568,10 @@
 		<default>2</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -11079,6 +11602,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>3</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -11123,6 +11650,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -11160,6 +11691,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -11201,6 +11736,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -11238,6 +11777,10 @@
 	<attribute>
 		<id>RAIL_NAME</id>
 		<default>UNKNOWN</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -11297,6 +11840,10 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -11346,6 +11893,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -11404,6 +11955,10 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -11441,6 +11996,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -11486,6 +12045,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO1</default>
 	</attribute>
@@ -11527,6 +12090,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -11572,6 +12139,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO3</default>
 	</attribute>
@@ -11613,6 +12184,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -11658,6 +12233,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO5</default>
 	</attribute>
@@ -11699,6 +12278,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -11744,6 +12327,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO7</default>
 	</attribute>
@@ -11785,6 +12372,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -11830,6 +12421,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO1.1</default>
 	</attribute>
@@ -11871,6 +12466,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -11916,6 +12515,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO1.3</default>
 	</attribute>
@@ -11957,6 +12560,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -12002,6 +12609,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO1.5</default>
 	</attribute>
@@ -12043,6 +12654,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
@@ -12088,6 +12703,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>SCHEMATIC_INTERFACE</id>
 		<default>IO1.7</default>
 	</attribute>
@@ -12124,6 +12743,10 @@
 		<default>1</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12154,6 +12777,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>2</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12188,6 +12815,10 @@
 		<default>3</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12218,6 +12849,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>4</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12252,6 +12887,10 @@
 		<default>5</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12282,6 +12921,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>6</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12316,6 +12959,10 @@
 		<default>7</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12340,6 +12987,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12362,6 +13013,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12399,6 +13054,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default></default>
 	</attribute>
@@ -12421,6 +13080,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12447,6 +13110,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default></default>
 	</attribute>
@@ -12471,6 +13138,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12493,6 +13164,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12535,6 +13210,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default></default>
 	</attribute>
@@ -12559,6 +13238,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12581,6 +13264,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12624,6 +13311,10 @@
 		<default>0</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>FSP</default>
 	</attribute>
@@ -12657,6 +13348,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12700,6 +13395,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12757,6 +13456,10 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12826,6 +13529,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12879,6 +13586,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -12936,6 +13647,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -12991,6 +13706,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13044,6 +13763,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -13109,6 +13832,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -13187,6 +13914,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13260,6 +13991,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -13337,6 +14072,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13410,6 +14149,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -13487,6 +14230,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13560,6 +14307,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -13637,6 +14388,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13710,6 +14465,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -13787,6 +14546,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -13860,6 +14623,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -13937,6 +14704,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14010,6 +14781,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14087,6 +14862,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14160,6 +14939,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14237,6 +15020,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14310,6 +15097,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14387,6 +15178,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14460,6 +15255,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14537,6 +15336,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14610,6 +15413,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14687,6 +15494,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14760,6 +15571,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14837,6 +15652,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -14910,6 +15729,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -14987,6 +15810,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15060,6 +15887,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>APSS_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15137,6 +15968,10 @@
 		<default>APSS_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15190,6 +16025,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15247,6 +16086,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15300,6 +16143,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15357,6 +16204,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15410,6 +16261,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15467,6 +16322,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15520,6 +16379,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15577,6 +16440,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15630,6 +16497,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>IPMI_SENSOR</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15687,6 +16558,10 @@
 		<default>IPMI_SENSOR</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15740,6 +16615,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -15800,6 +16679,10 @@
 		<default></default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15835,6 +16718,10 @@
 		<default>NA</default>
 	</attribute>
 	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
 		<id>TYPE</id>
 		<default>NA</default>
 	</attribute>
@@ -15857,6 +16744,10 @@
 	<attribute>
 		<id>MRW_TYPE</id>
 		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
 	</attribute>
 	<attribute>
 		<id>TYPE</id>
@@ -15913,6 +16804,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>
@@ -15982,6 +16877,10 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
 		<default>0</default>
 	</attribute>
 	<attribute>


### PR DESCRIPTION
```
-Update membuf fru id to point to a separate fru inventory
 record so that all the data fits correcty in a single record.
```

   -Remove opal fru id processing
